### PR TITLE
Fix for the plugin crashing on iOS 10 

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -71,6 +71,12 @@
                 <param name="ios-package" value="CsZBar"/>
             </feature>
         </config-file>
+
+        <!-- Declare Camera Usage for iOS10+ -->
+        <config-file target="*-Info.plist" parent="NSCameraUsageDescription">
+            <string>For Barcode Scanning</string>
+        </config-file>
+
         <framework src="AVFoundation.framework" />
         <framework src="CoreMedia.framework" />
         <framework src="CoreVideo.framework" />


### PR DESCRIPTION
Add NSCameraUsageDescription to info.plist when adding the plugin to an iOS project.

Without this, the plugin behavior on iOS 10 is as follows:
First call to `cloudSky.zBar.scan(params, onSuccess, onFailure)` prompts the user to give the app access to the iOS device's camera.
Second call to `cloudSky.zBar.scan(params, onSuccess, onFailure)`, and all subsequent calls, result in the error "A scan is already in progress." and the camera never opens.