### PR TITLE
ios11 fixes

### DIFF
--- a/ios/CsZBar.m
+++ b/ios/CsZBar.m
@@ -72,14 +72,14 @@
         }
 
         // Hack to hide the bottom bar's Info button... originally based on http://stackoverflow.com/a/16353530
-	NSInteger infoButtonIndex;
-        if ([[[UIDevice currentDevice] systemVersion] compare:@"10.0" options:NSNumericSearch] != NSOrderedAscending) {
-            infoButtonIndex = 1;
-        } else {
-            infoButtonIndex = 3;
-        }
-        UIView *infoButton = [[[[[self.scanReader.view.subviews objectAtIndex:2] subviews] objectAtIndex:0] subviews] objectAtIndex:infoButtonIndex];
-        [infoButton setHidden:YES];
+	// NSInteger infoButtonIndex;
+    //     if ([[[UIDevice currentDevice] systemVersion] compare:@"10.0" options:NSNumericSearch] != NSOrderedAscending) {
+    //         infoButtonIndex = 1;
+    //     } else {
+    //         infoButtonIndex = 3;
+    //     }
+    //     UIView *infoButton = [[[[[self.scanReader.view.subviews objectAtIndex:2] subviews] objectAtIndex:0] subviews] objectAtIndex:infoButtonIndex];
+    //     [infoButton setHidden:YES];
 
         //UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem]; [button setTitle:@"Press Me" forState:UIControlStateNormal]; [button sizeToFit]; [self.view addSubview:button];
         CGRect screenRect = [[UIScreen mainScreen] bounds];

--- a/plugin.xml
+++ b/plugin.xml
@@ -76,6 +76,9 @@
         <config-file target="*-Info.plist" parent="NSCameraUsageDescription">
             <string>For Barcode Scanning</string>
         </config-file>
+        <config-file target="*-Info.plist" parent="NSPhotoLibraryUsageDescription">
+            <string>Select Barcode For Scanning</string>
+        </config-file>
 
         <framework src="AVFoundation.framework" />
         <framework src="CoreMedia.framework" />


### PR DESCRIPTION
the info button hack lets the camera crash in ios11
and suddenly apps are rejected because the extra NSPhotoLibraryUsageDescription -info is needed.