### PR TITLE
Several fixes for iOS 12

### DIFF
--- a/ios/CsZBar.m
+++ b/ios/CsZBar.m
@@ -35,6 +35,24 @@
 
 #pragma mark - Plugin API
 
++ (UIView*) searchToolbarFrom:(UIView*) topView {
+    UIView* result = nil;
+    for (UIView* testView in topView.subviews) {
+        if([testView isKindOfClass:[UIToolbar class]]){
+            result = testView;
+            break;
+        } else {
+            if ([testView.subviews count] > 0){
+                result = [self searchToolbarFrom:testView];
+                if (result != nil){
+                    break;
+                }
+            }
+        }
+    }
+    return result;
+};
+
 - (void)scan: (CDVInvokedUrlCommand*)command; 
 {
     if (self.scanInProgress) {
@@ -49,7 +67,8 @@
         self.scanReader = [AlmaZBarReaderViewController new];
 
         self.scanReader.readerDelegate = self;
-        self.scanReader.supportedOrientationsMask = ZBarOrientationMask(UIInterfaceOrientationPortrait);
+        //self.scanReader.supportedOrientationsMask = ZBarOrientationMask(UIInterfaceOrientationPortrait);
+        self.scanReader.supportedOrientationsMask = ZBarOrientationMask(UIInterfaceOrientationPortrait || UIDeviceOrientationLandscapeRight || UIDeviceOrientationLandscapeLeft);
 
         // Get user parameters
         NSDictionary *params = (NSDictionary*) [command argumentAtIndex:0];
@@ -72,16 +91,22 @@
         }
 
         // Hack to hide the bottom bar's Info button... originally based on http://stackoverflow.com/a/16353530
-	NSInteger infoButtonIndex;
-        if ([[[UIDevice currentDevice] systemVersion] compare:@"10.0" options:NSNumericSearch] != NSOrderedAscending) {
-            infoButtonIndex = 1;
-        } else {
-            infoButtonIndex = 3;
-        }
-        UIView *infoButton = [[[[[self.scanReader.view.subviews objectAtIndex:2] subviews] objectAtIndex:0] subviews] objectAtIndex:infoButtonIndex];
-        [infoButton setHidden:YES];
 
-        //UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem]; [button setTitle:@"Press Me" forState:UIControlStateNormal]; [button sizeToFit]; [self.view addSubview:button];
+        UIView* testView = self.scanReader.view;
+        UIView* toolBar = [[self class] searchToolbarFrom:testView];
+        
+        for (UIBarButtonItem* item  in ((UIToolbar*)toolBar).items) {
+            if (item.customView != nil){
+                if([item.customView isKindOfClass:[UIButton class]]){
+                    UIButton* but = (UIButton*)item.customView;
+                    if (but.buttonType == UIButtonTypeInfoLight
+                        || but.buttonType == UIButtonTypeInfoDark){
+                        but.hidden = YES;
+                    }
+                }
+            }
+        }
+        
         CGRect screenRect = [[UIScreen mainScreen] bounds];
         CGFloat screenWidth = screenRect.size.width;
         CGFloat screenHeight = screenRect.size.height;
@@ -151,12 +176,27 @@
     
     ZBarSymbol *symbol = nil;
     for (symbol in results) break; // get the first result
+    
+    
+    
+    const char* initialData = [symbol.data UTF8String];
+    
+    NSUInteger bufferLength = [symbol.data lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
+    NSString* newString = [NSString new];
+    
+    for (int i=0; i<bufferLength; i++) {
+        if (initialData[i] < 30){
+            newString = [newString stringByAppendingString:@"\\x"];
+        } else {
+            newString =  [newString stringByAppendingString:[NSString stringWithFormat:@"%c" , initialData[i]]];
+        }
+    }
 
     [self.scanReader dismissViewControllerAnimated: YES completion: ^(void) {
         self.scanInProgress = NO;
         [self sendScanResult: [CDVPluginResult
                                resultWithStatus: CDVCommandStatus_OK
-                               messageAsString: symbol.data]];
+                               messageAsString: newString]];
     }];
 }
 


### PR DESCRIPTION
Fixed crash for the incorrect index of (i) button in ios 12;
Enabled landscape mode for scanning long GS1-128 codes (portrait mode has less resolution);
Added visualization non-printable symbols like (Function Code 1) which used in GS1-128 and cannot be converted "as is" to NSString as result JS app cannot see it and uses.